### PR TITLE
Change from plural to singular for path arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ All libsass options can be passed as keyword arguments:
 - `source_map_file_urls`: create file urls for sources
 - `source_map_root`: pass-through as sourceRoot property
 - `is_indented_syntax_src`: treat source_string as sass (as opposed to scss)
-- `include_paths` (`AbstractString` or `AbstractArray{<:AbstractString}`)
-- `plugin_paths` (`AbstractString` or `AbstractArray{<:AbstractString}`)
+- `include_path` (`AbstractString` or `AbstractArray{<:AbstractString}`)
+- `plugin_path` (`AbstractString` or `AbstractArray{<:AbstractString}`)
 - `indent`: string to be used for indentation
 - `linefeed`: string to be used to for line feeds
 - `input_path`: the input path is used for source map generating. It can be used to define something with string compilation or to overload the input file path. It is set to `stdin` for data contexts and to the input file on file contexts.

--- a/src/julian_api.jl
+++ b/src/julian_api.jl
@@ -32,8 +32,8 @@ arguments, are:
 - `source_map_file_urls`: create file urls for sources
 - `source_map_root`: pass-through as sourceRoot property
 - `is_indented_syntax_src`: treat source_string as sass (as opposed to scss)
-- `include_paths` (`AbstractString` or `AbstractArray{<:AbstractString}`)
-- `plugin_paths` (`AbstractString` or `AbstractArray{<:AbstractString}`)
+- `include_path` (`AbstractString` or `AbstractArray{<:AbstractString}`)
+- `plugin_path` (`AbstractString` or `AbstractArray{<:AbstractString}`)
 - `indent`: string to be used for indentation
 - `linefeed`: string to be used to for line feeds
 - `input_path`: the input path is used for source map generating. It can be used to define something with string compilation or to overload the input file path. It is set to `stdin` for data contexts and to the input file on file contexts.


### PR DESCRIPTION
This is only a documentation change, bringing the docs in line with both the Julia implementation and the C API.

Fix #12, based on the rationale in https://github.com/piever/Sass.jl/issues/12#issuecomment-585994067.