### PR TITLE
add compile_string() for compiling strings to css

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -44,9 +44,19 @@ end
 
 # Data
 
-function sass_make_data_context(data)
+function sass_copy_c_string(s)
+    ccall((:sass_copy_c_string, Sass.libsass_so),
+        Ptr{Cstring}, (Cstring,), s)
+end
+
+function sass_make_data_context(data::AbstractString)
+    # as sass assumes that it has control over the memory,
+    # we copy the data to memory that is under control of sass.
+    # Otherwise we would see segfaults when sass tries to free the memory.
+    sass_data = sass_copy_c_string(string(data))
+
     ccall((:sass_make_data_context, libsass_so),
-        Ptr{Cvoid}, (Ptr{UInt8},), data)
+        Ptr{Cvoid}, (Ptr{UInt8},), sass_data)
 end
 
 function sass_delete_data_context(context)

--- a/src/julian_api.jl
+++ b/src/julian_api.jl
@@ -100,7 +100,7 @@ end
 """
 `compile_string(data::AbstractString; kwargs...)`
 
-Compile `filename` from sass or scss to a css string. Possible options, given by keyword
+Compile sass or scss string to a css string. Possible options, given by keyword
 arguments, are:
 
 - `output_style`: output style for the generated css code. See `Sass.Style` for options. For example `output_style  = Sass.nested`
@@ -144,4 +144,64 @@ function compile_string(data::AbstractString; kwargs...)
 
     sass_delete_data_context(ctx)
     return css
+end
+
+"""
+    compile_sass(data; kwargs...)
+
+Compile sass string to a css string. Possible options, given by keyword
+arguments, are:
+
+- `output_style`: output style for the generated css code. See `Sass.Style` for options. For example `output_style  = Sass.nested`
+- `source_comments`: a boolean to specify whether to insert inline source comments
+- `indent`: string to be used for indentation
+- `linefeed`: string to be used for line feeds
+- `precision`: precision for outputting fractional numbers
+
+## Examples
+
+```julia
+julia> Sass.compile_sass(raw"
+       \$font-stack:    Helvetica, sans-serif
+       \$primary-color: #333
+
+       body
+           font: 100% \$font-stack
+           color: \$primary-color
+       ")
+"body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n"
+```
+"""
+function compile_sass(data; kwargs...)
+    compile_string(data; is_indented_syntax_src = true, kwargs...)
+end
+
+"""
+    compile_scss(data; kwargs...)
+
+Compile scss string to a css string. Possible options, given by keyword
+arguments, are:
+
+- `output_style`: output style for the generated css code. See `Sass.Style` for options. For example `output_style  = Sass.nested`
+- `source_comments`: a boolean to specify whether to insert inline source comments
+- `indent`: string to be used for indentation
+- `linefeed`: string to be used for line feeds
+- `precision`: precision for outputting fractional numbers
+
+## Examples
+
+```
+julia> Sass.compile_scss(raw"
+       \$font-stack:    Helvetica, sans-serif;
+       \$primary-color: #333;
+
+       body {
+           font: 100% \$font-stack;
+           color: \$primary-color;
+       }")
+"body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n"
+```
+"""
+function compile_scss(data; kwargs...)
+    compile_string(data; is_indented_syntax_src = false, kwargs...)
 end

--- a/src/julian_api.jl
+++ b/src/julian_api.jl
@@ -35,7 +35,7 @@ arguments, are:
 - `include_path` (`AbstractString` or `AbstractArray{<:AbstractString}`)
 - `plugin_path` (`AbstractString` or `AbstractArray{<:AbstractString}`)
 - `indent`: string to be used for indentation
-- `linefeed`: string to be used to for line feeds
+- `linefeed`: string to be used for line feeds
 - `input_path`: the input path is used for source map generating. It can be used to define something with string compilation or to overload the input file path. It is set to `stdin` for data contexts and to the input file on file contexts.
 - `output_path`: the output path is used for source map generating. LibSass will not write to this file, it is just used to create information in source-maps etc.
 - `precision`: precision for outputting fractional numbers
@@ -95,4 +95,53 @@ function compile_file(filename, dest; output_path = dest, source_map_file = noth
             write(io, src_map)
         end
     end
+end
+
+"""
+`compile_string(data::AbstractString; kwargs...)`
+
+Compile `filename` from sass or scss to a css string. Possible options, given by keyword
+arguments, are:
+
+- `output_style`: output style for the generated css code. See `Sass.Style` for options. For example `output_style  = Sass.nested`
+- `source_comments`: a boolean to specify whether to insert inline source comments
+- `is_indented_syntax_src`: treat source_string as sass (as opposed to scss)
+- `indent`: string to be used for indentation
+- `linefeed`: string to be used for line feeds
+- `precision`: precision for outputting fractional numbers
+
+## Examples
+
+```julia
+julia> Sass.compile_string(raw"
+       \$font-stack:    Helvetica, sans-serif
+       \$primary-color: #333
+
+       body
+         font: 100% \$font-stack
+         color: \$primary-color
+       ", is_indented_syntax_src = true)
+"body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n"
+```
+"""
+function compile_string(data::AbstractString; kwargs...)
+    data_ctx = sass_make_data_context(data);
+    ctx = sass_data_context_get_context(data_ctx);
+
+    options = sass_context_get_options(ctx)
+    for (key, val) in kwargs
+        setter = get(attributes_setters, key, nothing)
+        setter === nothing || setter(options, val)
+    end
+
+    sass_data_context_set_options(ctx, options)
+
+    status = sass_compile_data_context(data_ctx)
+
+    status == 0 || error(sass_context_get_error_text(ctx))
+
+    css =  sass_context_get_output_string(ctx)
+
+    sass_delete_data_context(ctx)
+    return css
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,20 @@ end
 
     css = Sass.compile_string(sass; output_style = Sass.nested, is_indented_syntax_src = true)
     @test css == "body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n"
+
+    css = Sass.compile_sass(sass)
+    @test css == "body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n"
+
+    scss = raw"
+    $font-stack:    Helvetica, sans-serif;
+    $primary-color: #333;
+
+    body {
+        font: 100% $font-stack;
+        color: $primary-color;
+    }"
+    css = Sass.compile_scss(scss)
+    @test css == "body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n"
 end
 
 @testset "wrongpath" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,15 @@ using Test
     @test css == "body{font:100% Helvetica,sans-serif;color:#333}\n"
 end
 
+@testset "compile_string" begin
+    filename = joinpath(Sass.examplefolder, "test.sass")
+    sass = read(filename, String)
+    @test_throws ErrorException Sass.compile_string(sass)
+
+    css = Sass.compile_string(sass; output_style = Sass.nested, is_indented_syntax_src = true)
+    @test css == "body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n"
+end
+
 @testset "wrongpath" begin
     filename = joinpath(Sass.examplefolder, "wrongpath.sass")
     @test_throws ErrorException Sass.compile_file(filename)


### PR DESCRIPTION
This PR fixes #2.
- modify `sass_make_data_context()` to always copy a Julia AbstractString to sass in order to prevent segfaults
- add compile_string() with corrected `sass_make_data_context()`
- add respective tests

The following code example from sass helped me to develop this PR
https://github.com/sass/libsass/blob/master/docs/api-context-example.md

Not sure whether this API is the optimal solution. One could think of having only `compile()` with multiple dispatch, or defining `compile_sass()`, `compile_scss()` with the respective setting of `is_indented_syntax_src`.

```julia
compile_sass(data; kwargs...) = compile_string(data; compile_sass = true, kwargs...)
compile_scss(data; kwargs...) = compile_string(data; compile_sass = false, kwargs...)
```
@piever Happy to hear what you think.